### PR TITLE
move switch from TWFdispatcher into TrialWaveFunction

### DIFF
--- a/src/QMCWaveFunctions/TWFdispatcher.cpp
+++ b/src/QMCWaveFunctions/TWFdispatcher.cpp
@@ -78,45 +78,18 @@ void TWFdispatcher::flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& 
                                   int iat,
                                   TWFGrads<CT>& grads) const
 {
-  if constexpr (CT == CoordsType::POS_SPIN)
-    flex_evalGradWithSpin(wf_list, p_list, iat, grads.grads_positions, grads.grads_spins);
-  else
-    flex_evalGrad(wf_list, p_list, iat, grads.grads_positions);
-}
-
-void TWFdispatcher::flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                  const RefVectorWithLeader<ParticleSet>& p_list,
-                                  int iat,
-                                  std::vector<GradType>& grad_now) const
-{
   assert(wf_list.size() == p_list.size());
   if (use_batch_)
-    TrialWaveFunction::mw_evalGrad(wf_list, p_list, iat, grad_now);
+    TrialWaveFunction::mw_evalGrad(wf_list, p_list, iat, grads);
   else
   {
     const int num_wf = wf_list.size();
-    grad_now.resize(num_wf);
+    grads.resize(num_wf);
     for (size_t iw = 0; iw < num_wf; iw++)
-      grad_now[iw] = wf_list[iw].evalGrad(p_list[iw], iat);
-  }
-}
-
-void TWFdispatcher::flex_evalGradWithSpin(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                          const RefVectorWithLeader<ParticleSet>& p_list,
-                                          int iat,
-                                          std::vector<GradType>& grad_now,
-                                          std::vector<Complex>& spingrad_now) const
-{
-  assert(wf_list.size() == p_list.size());
-  if (use_batch_)
-    TrialWaveFunction::mw_evalGradWithSpin(wf_list, p_list, iat, grad_now, spingrad_now);
-  else
-  {
-    const int num_wf = wf_list.size();
-    grad_now.resize(num_wf);
-    spingrad_now.resize(num_wf);
-    for (size_t iw = 0; iw < num_wf; iw++)
-      grad_now[iw] = wf_list[iw].evalGradWithSpin(p_list[iw], iat, spingrad_now[iw]);
+      if constexpr (CT == CoordsType::POS_SPIN)
+        grads.grads_positions[iw] = wf_list[iw].evalGradWithSpin(p_list[iw], iat, grads.grads_spins[iw]);
+      else
+        grads.grads_positions[iw] = wf_list[iw].evalGrad(p_list[iw], iat);
   }
 }
 
@@ -127,49 +100,19 @@ void TWFdispatcher::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFuncti
                                        std::vector<PsiValueType>& ratios,
                                        TWFGrads<CT>& grads) const
 {
-  if constexpr (CT == CoordsType::POS_SPIN)
-    flex_calcRatioGradWithSpin(wf_list, p_list, iat, ratios, grads.grads_positions, grads.grads_spins);
-  else
-    flex_calcRatioGrad(wf_list, p_list, iat, ratios, grads.grads_positions);
-}
-
-void TWFdispatcher::flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                       const RefVectorWithLeader<ParticleSet>& p_list,
-                                       int iat,
-                                       std::vector<PsiValueType>& ratios,
-                                       std::vector<GradType>& grad_new) const
-{
   assert(wf_list.size() == p_list.size());
   if (use_batch_)
-    TrialWaveFunction::mw_calcRatioGrad(wf_list, p_list, iat, ratios, grad_new);
+    TrialWaveFunction::mw_calcRatioGrad(wf_list, p_list, iat, ratios, grads);
   else
   {
     const int num_wf = wf_list.size();
     ratios.resize(num_wf);
-    grad_new.resize(num_wf);
+    grads.resize(num_wf);
     for (size_t iw = 0; iw < num_wf; iw++)
-      ratios[iw] = wf_list[iw].calcRatioGrad(p_list[iw], iat, grad_new[iw]);
-  }
-}
-
-void TWFdispatcher::flex_calcRatioGradWithSpin(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                               const RefVectorWithLeader<ParticleSet>& p_list,
-                                               int iat,
-                                               std::vector<PsiValueType>& ratios,
-                                               std::vector<GradType>& grad_new,
-                                               std::vector<Complex>& spingrad_new) const
-{
-  assert(wf_list.size() == p_list.size());
-  if (use_batch_)
-    TrialWaveFunction::mw_calcRatioGradWithSpin(wf_list, p_list, iat, ratios, grad_new, spingrad_new);
-  else
-  {
-    const int num_wf = wf_list.size();
-    ratios.resize(num_wf);
-    grad_new.resize(num_wf);
-    spingrad_new.resize(num_wf);
-    for (size_t iw = 0; iw < num_wf; iw++)
-      ratios[iw] = wf_list[iw].calcRatioGradWithSpin(p_list[iw], iat, grad_new[iw], spingrad_new[iw]);
+      if constexpr (CT == CoordsType::POS_SPIN)
+        ratios[iw] = wf_list[iw].calcRatioGradWithSpin(p_list[iw], iat, grads.grads_positions[iw], grads.grads_spins[iw]);
+      else
+        ratios[iw] = wf_list[iw].calcRatioGrad(p_list[iw], iat, grads.grads_positions[iw]);
   }
 }
 

--- a/src/QMCWaveFunctions/TWFdispatcher.h
+++ b/src/QMCWaveFunctions/TWFdispatcher.h
@@ -56,36 +56,12 @@ public:
                      int iat,
                      TWFGrads<CT>& grads) const;
 
-  void flex_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                     const RefVectorWithLeader<ParticleSet>& p_list,
-                     int iat,
-                     std::vector<GradType>& grad_now) const;
-
-  void flex_evalGradWithSpin(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                             const RefVectorWithLeader<ParticleSet>& p_list,
-                             int iat,
-                             std::vector<GradType>& grad_now,
-                             std::vector<Complex>& spingrad_now) const;
-
   template<CoordsType CT>
   void flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                           const RefVectorWithLeader<ParticleSet>& p_list,
                           int iat,
                           std::vector<PsiValueType>& ratios,
                           TWFGrads<CT>& grads) const;
-
-  void flex_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                          const RefVectorWithLeader<ParticleSet>& p_list,
-                          int iat,
-                          std::vector<PsiValueType>& ratios,
-                          std::vector<GradType>& grad_new) const;
-
-  void flex_calcRatioGradWithSpin(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
-                                  const RefVectorWithLeader<ParticleSet>& p_list,
-                                  int iat,
-                                  std::vector<PsiValueType>& ratios,
-                                  std::vector<GradType>& grad_new,
-                                  std::vector<Complex>& spingrad_new) const;
 
   void flex_accept_rejectMove(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                               const RefVectorWithLeader<ParticleSet>& p_list,

--- a/src/QMCWaveFunctions/TrialWaveFunction.cpp
+++ b/src/QMCWaveFunctions/TrialWaveFunction.cpp
@@ -150,12 +150,12 @@ void TrialWaveFunction::mw_evaluateLog(const RefVectorWithLeader<TrialWaveFuncti
   const int num_particles = p_leader.getTotalNum();
   auto initGandL          = [num_particles, czero](TrialWaveFunction& twf, ParticleSet::ParticleGradient& grad,
                                           ParticleSet::ParticleLaplacian& lapl) {
-             grad.resize(num_particles);
-             lapl.resize(num_particles);
-             grad           = czero;
-             lapl           = czero;
-             twf.log_real_  = czero;
-             twf.PhaseValue = czero;
+    grad.resize(num_particles);
+    lapl.resize(num_particles);
+    grad           = czero;
+    lapl           = czero;
+    twf.log_real_  = czero;
+    twf.PhaseValue = czero;
   };
   for (int iw = 0; iw < wf_list.size(); iw++)
     initGandL(wf_list[iw], g_list[iw], l_list[iw]);
@@ -527,6 +527,18 @@ TrialWaveFunction::GradType TrialWaveFunction::evalGradWithSpin(ParticleSet& P, 
   return grad_iat;
 }
 
+template<CoordsType CT>
+void TrialWaveFunction::mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                    const RefVectorWithLeader<ParticleSet>& p_list,
+                                    int iat,
+                                    TWFGrads<CT>& grads)
+{
+  if constexpr (CT == CoordsType::POS_SPIN)
+    mw_evalGradWithSpin(wf_list, p_list, iat, grads.grads_positions, grads.grads_spins);
+  else
+    mw_evalGrad(wf_list, p_list, iat, grads.grads_positions);
+}
+
 void TrialWaveFunction::mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                     const RefVectorWithLeader<ParticleSet>& p_list,
                                     int iat,
@@ -666,6 +678,19 @@ TrialWaveFunction::ValueType TrialWaveFunction::calcRatioGradWithSpin(ParticleSe
   LogValueType logratio = convertValueToLog(r);
   PhaseDiff             = std::imag(logratio);
   return static_cast<ValueType>(r);
+}
+
+template<CoordsType CT>
+void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                         const RefVectorWithLeader<ParticleSet>& p_list,
+                                         int iat,
+                                         std::vector<PsiValueType>& ratios,
+                                         TWFGrads<CT>& grads)
+{
+  if constexpr (CT == CoordsType::POS_SPIN)
+    mw_calcRatioGradWithSpin(wf_list, p_list, iat, ratios, grads.grads_positions, grads.grads_spins);
+  else
+    mw_calcRatioGrad(wf_list, p_list, iat, ratios, grads.grads_positions);
 }
 
 void TrialWaveFunction::mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
@@ -1331,5 +1356,28 @@ void TrialWaveFunction::initializeTWFFastDerivWrapper(const ParticleSet& P, TWFF
     {}
   }
 }
+
+//explicit instantiations
+template void TrialWaveFunction::mw_evalGrad<CoordsType::POS>(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                                                              const RefVectorWithLeader<ParticleSet>& p_list,
+                                                              int iat,
+                                                              TWFGrads<CoordsType::POS>& grads);
+template void TrialWaveFunction::mw_evalGrad<CoordsType::POS_SPIN>(
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+    const RefVectorWithLeader<ParticleSet>& p_list,
+    int iat,
+    TWFGrads<CoordsType::POS_SPIN>& grads);
+template void TrialWaveFunction::mw_calcRatioGrad<CoordsType::POS>(
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+    const RefVectorWithLeader<ParticleSet>& p_list,
+    int iat,
+    std::vector<PsiValueType>& ratios,
+    TWFGrads<CoordsType::POS>& grads);
+template void TrialWaveFunction::mw_calcRatioGrad<CoordsType::POS_SPIN>(
+    const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+    const RefVectorWithLeader<ParticleSet>& p_list,
+    int iat,
+    std::vector<PsiValueType>& ratios,
+    TWFGrads<CoordsType::POS_SPIN>& grads);
 
 } // namespace qmcplusplus

--- a/src/QMCWaveFunctions/TrialWaveFunction.h
+++ b/src/QMCWaveFunctions/TrialWaveFunction.h
@@ -29,6 +29,7 @@
 #include "type_traits/template_types.hpp"
 #include "Containers/MinimalContainers/RecordArray.hpp"
 #include "QMCWaveFunctions/TWFFastDerivWrapper.h"
+#include "TWFGrads.hpp"
 #ifdef QMC_CUDA
 #include "type_traits/CUDATypes.h"
 #endif
@@ -351,6 +352,18 @@ public:
   /** batched version of ratioGrad
    *
    *  all vector sizes must match
+   *  implements switch between normal and WithSpin version
+   */
+  template<CoordsType CT>
+  static void mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                               const RefVectorWithLeader<ParticleSet>& p_list,
+                               int iat,
+                               std::vector<PsiValueType>& ratios,
+                               TWFGrads<CT>& grads);
+
+  /** batched version of ratioGrad
+   *
+   *  all vector sizes must match
    */
   static void mw_calcRatioGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
                                const RefVectorWithLeader<ParticleSet>& p_list,
@@ -395,6 +408,18 @@ public:
    *
    */
   GradType evalGradWithSpin(ParticleSet& P, int iat, ComplexType& spingrad);
+
+  /** batched version of evalGrad
+    *
+    * This is static because it should have no direct access
+    * to any TWF.
+    * implements switch between normal and WithSpin version
+    */
+  template<CoordsType CT>
+  static void mw_evalGrad(const RefVectorWithLeader<TrialWaveFunction>& wf_list,
+                          const RefVectorWithLeader<ParticleSet>& p_list,
+                          int iat,
+                          TWFGrads<CT>& grads);
 
   /** batched version of evalGrad
     *


### PR DESCRIPTION
Please review the [developer documentation](https://github.com/QMCPACK/qmcpack/wiki/Development-workflow)
on the wiki of this project that contains help and requirements.

## Proposed changes
per a request from Ye to help review go easier, this is forked from batched_driver_move_abstraction and moves the "switch"  between POS/POS_SPIN from TWFdispatcher into TrialWaveFunction
## What type(s) of changes does this code introduce?
_Delete the items that do not apply_

- Refactor

### Does this introduce a breaking change?

- No

## What systems has this change been tested on?
macOSX

## Checklist

_Update the following with a yes where the items apply. If you're unsure about any of them, don't hesitate to ask.  This is
simply a reminder of what we are going to look for before merging your code._

- No. This PR is up to date with current the current state of 'develop'
- Yes. Code added or changed in the PR has been clang-formatted
- No. This PR adds tests to cover any new code, or to catch a bug that is being fixed
- No. Documentation has been added (if appropriate)
